### PR TITLE
Add vendored-openssl feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +900,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -32,3 +32,6 @@ penguin = { version = "0.1.4", path = "../lib" }
 pretty_env_logger = "0.4"
 structopt = "0.3"
 tokio = { version = "1", features = ["rt", "macros"]}
+
+[features]
+vendored-openssl = ["penguin/vendored-openssl"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,3 +34,6 @@ tokio-util = { version = "0.6.3", features = ["codec"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"]}
+
+[features]
+vendored-openssl = ["hyper-tls/vendored"]


### PR DESCRIPTION
This feature lets users build OpenSSL from source when building this app, which makes e. g. cross-compilation much more convenient.